### PR TITLE
変数名を変更することで、古いバージョンだとエラーで落ちるようにする

### DIFF
--- a/flutter/lib/app/pages/splash.dart
+++ b/flutter/lib/app/pages/splash.dart
@@ -33,7 +33,7 @@ class _SplashPageState extends State<SplashPage> {
     Status status = await StatusRepository().getStatus();
     AlertRepository().slackUrl = status.slackUrl;
     widget.setStatus(status);
-    if (status.isMaintenance) {
+    if (status.isMaintenanceMode) {
       Navigator.pushReplacementNamed(context, '/maintenance');
       return;
     }

--- a/flutter/lib/domain/entity/status.dart
+++ b/flutter/lib/domain/entity/status.dart
@@ -4,14 +4,14 @@ import 'package:cellar/repository/repositories.dart';
 class Status {
   Map<DrinkType, int> uploadCounts;
   String requiredVersion;
-  bool isMaintenance;
+  bool isMaintenanceMode;
   String maintenanceMessage;
   String slackUrl;
 
   Status(
     this.uploadCounts,
     this.requiredVersion,
-    this.isMaintenance,
+    this.isMaintenanceMode,
     this.maintenanceMessage,
     this.slackUrl,
   );
@@ -44,6 +44,6 @@ class Status {
 
   @override
   String toString() {
-    return 'isMaintenance: $isMaintenance, uploadCounts: $uploadCounts';
+    return 'isMaintenanceMode: $isMaintenanceMode, uploadCounts: $uploadCounts';
   }
 }

--- a/flutter/lib/repository/status_repository.dart
+++ b/flutter/lib/repository/status_repository.dart
@@ -63,7 +63,7 @@ class StatusRepository extends DB {
     return Status(
       counts,
       statusData.get('requiredVersion'),
-      statusData.get('isMaintenance'),
+      statusData.get('isMaintenanceMode'),
       statusData.get('maintenanceMessage'),
       statusData.get('slackUrl'),
     );


### PR DESCRIPTION
非公開機能を導入するにあたり、バージョンの強制アップデートが必要なので
古いバージョンだと動かないようにしてしまう